### PR TITLE
Devtools

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -2,8 +2,11 @@ import 'babel-core/polyfill';
 import ReactDOM from 'react-dom';
 import React from 'react';
 import Root from './pages/Root';
+import configureStore from './store/configureStore';
+
+const store = configureStore();
 
 ReactDOM.render(
-  <Root />,
+  <Root store={store} />,
   document.getElementById('root')
 );

--- a/app/package.json
+++ b/app/package.json
@@ -28,6 +28,7 @@
     "jsdom": "^6.5.1",
     "mocha": "^2.3.3",
     "react-hot-loader": "^1.3.0",
+    "redux-devtools": "^2.1.5",
     "webpack": "^1.12.2",
     "webpack-dev-server": "^1.12.0"
   },

--- a/app/package.json
+++ b/app/package.json
@@ -34,6 +34,8 @@
   "dependencies": {
     "immutable": "^3.7.5",
     "react": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "react-dom": "^0.14.0",
+    "react-redux": "^4.0.0",
+    "redux": "^3.0.4"
   }
 }

--- a/app/pages/Root.js
+++ b/app/pages/Root.js
@@ -1,21 +1,27 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import App from './App';
-import { createStore } from 'redux';
 import { Provider } from 'react-redux';
-import rootReducer from '../reducers';
-
-const store = createStore(rootReducer);
+import { DevTools, DebugPanel, LogMonitor } from 'redux-devtools/lib/react';
 
 const Root = React.createClass({
   displayName: 'Root',
 
   render() {
     return (
-      <Provider store={store}>
-        <App />
-      </Provider>
+      <div>
+        <Provider store={this.props.store}>
+          <App />
+        </Provider>
+        <DebugPanel top right bottom>
+          <DevTools store={this.props.store} monitor={LogMonitor} />
+        </DebugPanel>
+      </div>
     );
   }
 });
+
+Root.propTypes = {
+  store: PropTypes.object.isRequired
+};
 
 export default Root;

--- a/app/store/configureStore.dev.js
+++ b/app/store/configureStore.dev.js
@@ -1,0 +1,21 @@
+import { createStore, compose } from 'redux';
+import { devTools } from 'redux-devtools';
+import rootReducer from '../reducers';
+
+const finalCreateStore = compose(
+  devTools()
+)(createStore);
+
+export default function configureStore(initialState) {
+  const store = finalCreateStore(rootReducer, initialState);
+
+  if (module.hot) {
+    // Enable Webpack hot module replacement for reducers
+    module.hot.accept('../reducers', () => {
+      const nextRootReducer = require('../reducers');
+      store.replaceReducer(nextRootReducer);
+    });
+  }
+
+  return store;
+}

--- a/app/store/configureStore.js
+++ b/app/store/configureStore.js
@@ -1,0 +1,5 @@
+if (process.env.NODE_ENV === 'production') {
+  module.exports = require('./configureStore.prod');
+} else {
+  module.exports = require('./configureStore.dev');
+}

--- a/app/webpack.config.js
+++ b/app/webpack.config.js
@@ -4,6 +4,7 @@ var webpack = require('webpack');
 var path = require('path');
 
 module.exports = {
+  devtool: 'inline-source-map',
   entry: [
     'webpack-dev-server/client?http://localhost:8080',
     'webpack/hot/only-dev-server',


### PR DESCRIPTION
#### What's this PR do?
Adds the redux devtools and some architecture tweaks.
#### Where should the reviewer start?
Notice that the `store` gets created at the root `index.js` level now and is passed to the Root component.
#### How should this be manually tested?
Running the app (`webpack-dev-server`) should display the devtools toolbar on the right side of the browser.
#### Any background context you want to provide?
Will added source map creation as a config in `webpack.config.js`. This speeds up debugging in the browser by letting you poke through your source code there.

Also, we neglected to save `redux` and `react-redux` libs in `package.json`. Now they're there.
#### What gif best describes this PR or how it makes you feel?

![](http://i.giphy.com/tn3kTJo4P4y1G.gif)
