### PR TITLE
Extracts dev tools to separate window

### DIFF
--- a/app/containers/Root.js
+++ b/app/containers/Root.js
@@ -1,7 +1,6 @@
 import React, { PropTypes } from 'react';
 import { Provider } from 'react-redux';
 import { ReduxRouter } from 'redux-router';
-import { DevTools, DebugPanel, LogMonitor } from 'redux-devtools/lib/react';
 
 const Root = React.createClass({
   displayName: 'Root',
@@ -12,9 +11,6 @@ const Root = React.createClass({
         <Provider store={this.props.store}>
           <ReduxRouter />
         </Provider>
-        <DebugPanel top right bottom>
-          <DevTools store={this.props.store} monitor={LogMonitor} />
-        </DebugPanel>
       </div>
     );
   }

--- a/app/createDevToolsWindow.js
+++ b/app/createDevToolsWindow.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render } from 'react-dom';
+import { DevTools, DebugPanel, LogMonitor } from 'redux-devtools/lib/react';
+
+/*
+ * Puts Redux DevTools into a separate window.
+ * Based on https://gist.github.com/tlrobinson/1e63d15d3e5f33410ef7#gistcomment-1560218.
+ */
+export default function createDevToolsWindow(store) {
+  // Give it a name so it reuses the same window
+  const name = 'Redux DevTools';
+  const win = window.open(
+    null,
+    name,
+    'menubar=no,location=no,resizable=yes,scrollbars=no,status=no,width=450,height=5000'
+  );
+
+  if (!win) {
+    console.error( // eslint-disable-line no-console
+      'Couldn\'t open Redux DevTools due to a popup blocker. ' +
+      'Please disable the popup blocker for the current page.'
+    );
+    return;
+  }
+
+  // Reload in case it's reusing the same window with the old content.
+  win.location.reload();
+
+  // Set visible Window title.
+  win.document.title = name;
+
+  // Wait a little bit for it to reload, then render.
+  setTimeout(() => render(
+    <DebugPanel top right bottom left>
+      <DevTools store={store} monitor={LogMonitor} />
+    </DebugPanel>,
+    win.document.body.appendChild(document.createElement('div'))
+  ), 10);
+}

--- a/app/index.js
+++ b/app/index.js
@@ -10,3 +10,11 @@ render(
   <Root store={store} />,
   document.getElementById('root')
 );
+
+if (process.env.NODE_ENV !== 'production') {
+  // Use require because imports can't be conditional.
+  // In production, you should ensure process.env.NODE_ENV
+  // is envified so that Uglify can eliminate this
+  // module and its dependencies as dead code.
+  require('./createDevToolsWindow')(store);
+}


### PR DESCRIPTION
#### What's this PR do?
Pulls dev tools out into its own window.
#### Where should the reviewer start?
Tools kicked off in `app/index.js` instead of the Root component now.
#### How should this be manually tested?
`npm start`, open localhost:3000, see a separate window pop up with the dev tools.
#### Any background context you want to provide?
I got annoyed with not being able to use the right third of the window. There's valuable UI under there, guy. This code is lifted from the redux real-world example.
#### Screenshots (if appropriate)
<img width="1279" alt="screen shot 2015-12-05 at 12 54 12 pm" src="https://cloud.githubusercontent.com/assets/3621728/11609890/b614a298-9b4f-11e5-926f-54c7e596cf7e.png">
#### What gif best describes this PR or how it makes you feel?
![awwyeah](https://cloud.githubusercontent.com/assets/3621728/11609896/14c3d1e2-9b50-11e5-98b4-dba24ce7d998.gif)
